### PR TITLE
Replaced cookbook file for APT sources with a template so that the recipe considers distro codename (Ubuntu)

### DIFF
--- a/files/default/percona_repo.list
+++ b/files/default/percona_repo.list
@@ -1,2 +1,0 @@
-deb http://repo.percona.com/apt lucid main
-deb-src http://repo.percona.com/apt lucid main

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -40,7 +40,8 @@ when "debian","ubuntu"
 	  command "gpg --keyserver  hkp://keys.gnupg.net --recv-keys 1C4CBDCDCD2EFD2A | gpg -a --export CD2EFD2A | apt-key add -; apt-get update"
 	end
 
-	cookbook_file "/etc/apt/sources.list.d/percona_repo.list" do
+	template "/etc/apt/sources.list.d/percona_repo.list" do
+      source "percona_repo.list.erb"
 	  owner "root"
 	  group "root"
 	  mode "0644"

--- a/templates/default/percona_repo.list.erb
+++ b/templates/default/percona_repo.list.erb
@@ -1,0 +1,2 @@
+deb http://repo.percona.com/apt <%= node[:lsb][:codename] %> main
+deb-src http://repo.percona.com/apt <%= node[:lsb][:codename] %> main


### PR DESCRIPTION
The current recipe failed with Precise Pangolin on a fresh EC2 instance. I modified it so that the APT source file is generated using the distribution codename (lucid, maverick, precise, and so on).
