### PR TITLE
add keyserver attribute for ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ none
 Attributes
 ==========
 
+* `node['percona-install']['keyserver']` - change the keyserver here, if necessary. 
+
 These attributes are used by the monitoring recipe:
 
 * `node['percona-install']['plugins_url']` - The base URL for the percona-monitoring-plugins

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,8 +16,13 @@
 # limitations under the License.
 #
 # http://www.percona.com/downloads/percona-monitoring-plugins/percona-monitoring-plugins-0.9.0.tar.gz
+
+default['percona-install']['keyserver'] = "keys.gnupg.net"
+
 default['percona-install']['plugins_url'] = "http://www.percona.com/downloads/percona-monitoring-plugins/"
 default['percona-install']['plugins_version'] = "0.9.0"
 default['percona-install']['plugins_sha'] = "04a7ace4c345ddc2a6b26cae0f6252533663d809008f284919b207b9a00e4a44"
 default['percona-install']['plugins_path'] = "/opt/pmp"
 default['percona-install']['plugins_nagios'] = "/opt/pmp/nagios/bin"
+
+

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,6 +13,11 @@ recipe           "xtrabackup", "Installs Percona xtrabackup"
 recipe           "monitoring", "Installs Percona monitoring plugins"
 recipe           "toolkit", "Installs Percona toolkit"
 
+attribute "percona-install/keyserver", 
+  :dislpay_name => "Percona Install - Keyserver",
+  :description => "The keyserver to use",
+  :type => "string"
+
 attribute "percona-install/plugins_url", 
   :dislpay_name => "Percona Install - Plugins URL",
   :description => "The base URL for the percona-monitoring-plugins",

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,7 +38,7 @@ when "debian","ubuntu"
 
   execute "key-install" do
     action :nothing
-    command "gpg --keyserver  hkp://keys.gnupg.net --recv-keys 1C4CBDCDCD2EFD2A | gpg -a --export CD2EFD2A | apt-key add - && apt-get update"
+    command "gpg --keyserver  hkp://#{node['percona-install']['keyserver']} --recv-keys 1C4CBDCDCD2EFD2A | gpg -a --export CD2EFD2A | apt-key add - && apt-get update"
   end
 
   template "/etc/apt/sources.list.d/percona_repo.list" do


### PR DESCRIPTION
Needed in the case of today, where the keys.gnupg.net server was going down.
