### PR TITLE
better idempotency on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ none
 Attributes
 ==========
 
+* `node['percona-install']['keyserver']` - change the keyserver here, if necessary. 
+
 These attributes are used by the monitoring recipe:
 
 * `node['percona-install']['plugins_url']` - The base URL for the percona-monitoring-plugins

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,8 +16,13 @@
 # limitations under the License.
 #
 # http://www.percona.com/downloads/percona-monitoring-plugins/percona-monitoring-plugins-0.9.0.tar.gz
+
+default['percona-install']['keyserver'] = "keys.gnupg.net"
+
 default['percona-install']['plugins_url'] = "http://www.percona.com/downloads/percona-monitoring-plugins/"
 default['percona-install']['plugins_version'] = "0.9.0"
 default['percona-install']['plugins_sha'] = "04a7ace4c345ddc2a6b26cae0f6252533663d809008f284919b207b9a00e4a44"
 default['percona-install']['plugins_path'] = "/opt/pmp"
 default['percona-install']['plugins_nagios'] = "/opt/pmp/nagios/bin"
+
+

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,6 +13,11 @@ recipe           "xtrabackup", "Installs Percona xtrabackup"
 recipe           "monitoring", "Installs Percona monitoring plugins"
 recipe           "toolkit", "Installs Percona toolkit"
 
+attribute "percona-install/keyserver", 
+  :dislpay_name => "Percona Install - Keyserver",
+  :description => "The keyserver to use",
+  :type => "string"
+
 attribute "percona-install/plugins_url", 
   :dislpay_name => "Percona Install - Plugins URL",
   :description => "The base URL for the percona-monitoring-plugins",

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,16 +36,16 @@ when "redhat","centos","fedora","suse", "amazon", "scientific"
 
 when "debian","ubuntu"
 
-  execute "key-install" do
-    action :nothing
-    command "gpg --keyserver  hkp://#{node['percona-install']['keyserver']} --recv-keys 1C4CBDCDCD2EFD2A | gpg -a --export CD2EFD2A | apt-key add - && apt-get update"
-  end
-
   template "/etc/apt/sources.list.d/percona_repo.list" do
     source "percona_repo.list.erb"
     owner "root"
     group "root"
     mode "0644"
-    notifies :run, "execute[key-install]", :immediately
   end
+  
+  execute "key-install" do
+    action :run
+    command "gpg --keyserver  hkp://#{node['percona-install']['keyserver']} --recv-keys 1C4CBDCDCD2EFD2A | gpg -a --export CD2EFD2A | apt-key add - && apt-get update"
+    not_if "apt-key list | grep CD2EFD2A"
+  end  
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,7 +38,7 @@ when "debian","ubuntu"
 
   execute "key-install" do
     action :nothing
-    command "gpg --keyserver  hkp://keys.gnupg.net --recv-keys 1C4CBDCDCD2EFD2A | gpg -a --export CD2EFD2A | apt-key add - && apt-get update"
+    command "gpg --keyserver  hkp://#{node['percona-install']['keyserver']} --recv-keys 1C4CBDCDCD2EFD2A | gpg -a --export CD2EFD2A | apt-key add - && apt-get update"
   end
 
   template "/etc/apt/sources.list.d/percona_repo.list" do


### PR DESCRIPTION
when GPG fails (due to a downed keyserver, for example), the key does not get added and it does not retry the next time due to it not being triggered because the template file already exists. This makes it check for existence using apt-key list. 

This also includes the keyserver attribute patch since I couldn't figure out how to separate them...
